### PR TITLE
feat: lead capture modals, route-based CTA flows, and leads analysis page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
   },
   "dependencies": {
     "@next/third-parties": "14.2.4",
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.105.3",
     "next": "14.2.4",
     "react": "18",
+    "react-datepicker": "^9.1.0",
     "react-dom": "18",
+    "react-hook-form": "^7.75.0",
     "react-icons": "5.2.1",
     "sharp": "0.33.4",
     "swiper": "11.1.4"
@@ -20,6 +24,7 @@
   "devDependencies": {
     "@types/node": "20",
     "@types/react": "18",
+    "@types/react-datepicker": "^7.0.0",
     "@types/react-dom": "18",
     "eslint": "8",
     "eslint-config-next": "14.2.4",

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceRoleClient } from "@/utils/supabase/server";
+import { getEnv } from "@/modules/utils";
+
+const PAGE_SIZE = 50;
+
+export async function GET(request: NextRequest) {
+  const password = request.headers.get("x-admin-password");
+
+  if (!password || password !== getEnv("ADMIN_PASSWORD")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+  const search = searchParams.get("search") || "";
+  const source = searchParams.get("source");
+  const neighborhood = searchParams.get("neighborhood") || "";
+  const dateFrom = searchParams.get("date_from") || "";
+  const dateTo = searchParams.get("date_to") || "";
+
+  const supabase = createServiceRoleClient();
+
+  let query = supabase
+    .from("leads")
+    .select("*", { count: "exact" })
+    .order("created_at", { ascending: false });
+
+  if (search) {
+    query = query.ilike("full_name", `%${search}%`);
+  }
+
+  if (source !== null && source !== "") {
+    query = query.eq("source", parseInt(source, 10));
+  }
+
+  if (neighborhood) {
+    query = query.ilike("neighborhood", `%${neighborhood}%`);
+  }
+
+  if (dateFrom) {
+    query = query.gte("created_at", dateFrom);
+  }
+
+  if (dateTo) {
+    query = query.lte("created_at", `${dateTo}T23:59:59.999Z`);
+  }
+
+  const from = (page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+  query = query.range(from, to);
+
+  const { data, count, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data, count });
+}
+
+export async function DELETE(request: NextRequest) {
+  const password = request.headers.get("x-admin-password");
+
+  if (!password || password !== getEnv("ADMIN_PASSWORD")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await request.json();
+
+  if (!id) {
+    return NextResponse.json({ error: "ID is required" }, { status: 400 });
+  }
+
+  const supabase = createServiceRoleClient();
+  const { error } = await supabase.from("leads").delete().eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/cuidadores/page.module.css
+++ b/src/app/cuidadores/page.module.css
@@ -1,0 +1,19 @@
+.main {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  width: 100vw;
+}
+
+@media (min-width: 515px) {
+  .main {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 514px) {
+  .main {
+    justify-content: flex-start;
+    gap: 0.5rem;
+  }
+}

--- a/src/app/cuidadores/page.tsx
+++ b/src/app/cuidadores/page.tsx
@@ -9,14 +9,15 @@ import {
   GoogleReviewsSection,
 } from "@/sections";
 import { BodyWrapper } from "@/components";
+import { FormSources } from "@/modules/constants";
 
 import styles from "./page.module.css";
 import { getEnv } from "@/modules/utils";
 
-const Home = () => (
+const Cuidadores = () => (
   <>
     <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
-    <BodyWrapper ctaMode="direct">
+    <BodyWrapper ctaMode="full" defaultSource={FormSources.P_MAX}>
       <main className={styles.main}>
         <BannerSection maxHeight="640px" />
         <YoutubeSection />
@@ -29,4 +30,4 @@ const Home = () => (
   </>
 );
 
-export default Home;
+export default Cuidadores;

--- a/src/app/empresa-de-cuidadores/page.module.css
+++ b/src/app/empresa-de-cuidadores/page.module.css
@@ -1,0 +1,19 @@
+.main {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  width: 100vw;
+}
+
+@media (min-width: 515px) {
+  .main {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 514px) {
+  .main {
+    justify-content: flex-start;
+    gap: 0.5rem;
+  }
+}

--- a/src/app/empresa-de-cuidadores/page.tsx
+++ b/src/app/empresa-de-cuidadores/page.tsx
@@ -9,14 +9,15 @@ import {
   GoogleReviewsSection,
 } from "@/sections";
 import { BodyWrapper } from "@/components";
+import { FormSources } from "@/modules/constants";
 
 import styles from "./page.module.css";
 import { getEnv } from "@/modules/utils";
 
-const Home = () => (
+const EmpresaDeCuidadores = () => (
   <>
     <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
-    <BodyWrapper ctaMode="direct">
+    <BodyWrapper ctaMode="lead-only" defaultSource={FormSources.REDE_DE_PESQUISA}>
       <main className={styles.main}>
         <BannerSection maxHeight="640px" />
         <YoutubeSection />
@@ -29,4 +30,4 @@ const Home = () => (
   </>
 );
 
-export default Home;
+export default EmpresaDeCuidadores;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
+import { Poppins } from "next/font/google";
 import "./globals.css";
+
+const poppins = Poppins({ subsets: ["latin"], weight: ["300", "400", "500"] });
 
 export const metadata: Metadata = {
   title: "Acuidar Jardins",
@@ -10,6 +13,12 @@ const RootLayout = ({
   children,
 }: Readonly<{
   children: React.ReactNode;
-}>) => <html lang="pt_BR">{children}</html>;
+}>) => (
+  <html lang="pt_BR">
+    <body className={poppins.className} suppressHydrationWarning={true}>
+      {children}
+    </body>
+  </html>
+);
 
 export default RootLayout;

--- a/src/app/leads/analysis/components/auth-gate.module.css
+++ b/src/app/leads/analysis/components/auth-gate.module.css
@@ -1,0 +1,103 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+  background: #e7ecec;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  background: #fff;
+  padding: 48px 36px;
+  border-radius: 20px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.08);
+  width: 100%;
+  max-width: 400px;
+}
+
+.icon_wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  background: #f0f5eb;
+  border-radius: 50%;
+  margin-bottom: 4px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 500;
+  color: #132e33;
+  text-align: center;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #666;
+  text-align: center;
+}
+
+.error {
+  font-size: 13px;
+  color: #d32f2f;
+  background: #fef2f2;
+  padding: 8px 14px;
+  border-radius: 8px;
+  width: 100%;
+  text-align: center;
+}
+
+.input {
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  font-size: 15px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.input:focus {
+  border-color: #78a046;
+  box-shadow: 0 0 0 3px rgba(120, 160, 70, 0.15);
+}
+
+.button {
+  width: 100%;
+  padding: 14px;
+  background: #78a046;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 500;
+  font-family: inherit;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.button:hover {
+  background: #5e8035;
+}
+
+.loading_text {
+  font-size: 14px;
+  color: #666;
+  margin-top: 8px;
+}
+
+@media (max-width: 480px) {
+  .card {
+    padding: 36px 24px;
+  }
+}

--- a/src/app/leads/analysis/components/auth-gate.tsx
+++ b/src/app/leads/analysis/components/auth-gate.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import Spinner from "./spinner";
+import styles from "./auth-gate.module.css";
+
+type AuthGateProps = {
+  onSubmit: (password: string) => void;
+  error: string;
+  loading: boolean;
+};
+
+const AuthGate = ({ onSubmit, error, loading }: AuthGateProps) => {
+  const [input, setInput] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    onSubmit(input);
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.card}>
+          <Spinner size="lg" />
+          <p className={styles.loading_text}>Verificando acesso...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <form className={styles.card} onSubmit={handleSubmit}>
+        <div className={styles.icon_wrapper}>
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#132e33" strokeWidth="1.5">
+            <rect x="3" y="11" width="18" height="11" rx="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+        </div>
+        <h1 className={styles.title}>Acesso Restrito</h1>
+        <p className={styles.subtitle}>
+          Insira a senha para acessar a análise de leads.
+        </p>
+        {error && <p className={styles.error}>{error}</p>}
+        <input
+          type="password"
+          className={styles.input}
+          placeholder="Senha"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          autoFocus
+        />
+        <button type="submit" className={styles.button}>
+          Entrar
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default AuthGate;

--- a/src/app/leads/analysis/components/date-input.module.css
+++ b/src/app/leads/analysis/components/date-input.module.css
@@ -1,0 +1,117 @@
+.wrapper {
+  position: relative;
+}
+
+.input {
+  width: 100%;
+  height: 40px;
+  padding: 0 12px 0 36px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  background: #fff;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+}
+
+.input:focus {
+  border-color: #78a046;
+  box-shadow: 0 0 0 3px rgba(120, 160, 70, 0.15);
+}
+
+.icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.wrapper :global(.react-datepicker) {
+  font-family: inherit !important;
+  border: none !important;
+  border-radius: 12px !important;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1) !important;
+}
+
+.wrapper :global(.react-datepicker__header) {
+  background: #f0f5eb !important;
+  border-bottom: 1px solid #e0e0e0 !important;
+  padding-top: 12px !important;
+  border-radius: 12px 12px 0 0 !important;
+}
+
+.wrapper :global(.react-datepicker__current-month) {
+  font-size: 14px !important;
+  font-weight: 500 !important;
+  color: #132e33 !important;
+  margin-bottom: 4px !important;
+}
+
+.wrapper :global(.react-datepicker__day-name) {
+  font-size: 11px !important;
+  color: #666 !important;
+  font-weight: 500 !important;
+  width: 32px !important;
+  line-height: 32px !important;
+}
+
+.wrapper :global(.react-datepicker__day) {
+  width: 32px !important;
+  line-height: 32px !important;
+  border-radius: 6px !important;
+  font-size: 13px !important;
+  transition: background 0.15s !important;
+}
+
+.wrapper :global(.react-datepicker__day:hover) {
+  background: #f0f5eb !important;
+}
+
+.wrapper :global(.react-datepicker__day--selected) {
+  background: #78a046 !important;
+  color: #fff !important;
+  font-weight: 500 !important;
+}
+
+.wrapper :global(.react-datepicker__day--keyboard-selected) {
+  background: #f0f5eb !important;
+  color: #333 !important;
+}
+
+.wrapper :global(.react-datepicker__day--today) {
+  font-weight: 600 !important;
+  color: #78a046 !important;
+}
+
+.wrapper :global(.react-datepicker__day--today.react-datepicker__day--selected) {
+  color: #fff !important;
+}
+
+.wrapper :global(.react-datepicker__navigation) {
+  top: 12px !important;
+}
+
+.wrapper :global(.react-datepicker__navigation-icon::before) {
+  border-color: #666 !important;
+  border-width: 2px 2px 0 0 !important;
+}
+
+.wrapper :global(.react-datepicker__close-icon::after) {
+  background: #999 !important;
+  font-size: 14px !important;
+  padding: 0 !important;
+  width: 16px !important;
+  height: 16px !important;
+  line-height: 16px !important;
+}
+
+.wrapper :global(.react-datepicker__triangle) {
+  display: none !important;
+}
+
+.wrapper :global(.react-datepicker-popper) {
+  z-index: 50 !important;
+}

--- a/src/app/leads/analysis/components/date-input.tsx
+++ b/src/app/leads/analysis/components/date-input.tsx
@@ -1,0 +1,50 @@
+import DatePicker, { registerLocale } from "react-datepicker";
+import { ptBR } from "date-fns/locale/pt-BR";
+import "react-datepicker/dist/react-datepicker.css";
+import styles from "./date-input.module.css";
+
+registerLocale("pt-BR", ptBR);
+
+type DateInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+};
+
+const DateInput = ({ value, onChange, placeholder = "dd/mm/aaaa" }: DateInputProps) => {
+  const selected = value ? new Date(value + "T00:00:00") : null;
+
+  const handleChange = (date: Date | null) => {
+    if (date) {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      onChange(`${year}-${month}-${day}`);
+    } else {
+      onChange("");
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <DatePicker
+        selected={selected}
+        onChange={handleChange}
+        locale="pt-BR"
+        dateFormat="dd/MM/yyyy"
+        placeholderText={placeholder}
+        className={styles.input}
+        isClearable
+        showPopperArrow={false}
+      />
+      <svg className={styles.icon} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#999" strokeWidth="2">
+        <rect x="3" y="4" width="18" height="18" rx="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </svg>
+    </div>
+  );
+};
+
+export default DateInput;

--- a/src/app/leads/analysis/components/leads-filters.module.css
+++ b/src/app/leads/analysis/components/leads-filters.module.css
@@ -1,0 +1,107 @@
+.container {
+  background: #fff;
+  border-radius: 14px;
+  padding: 20px 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.search_wrapper {
+  position: relative;
+  max-width: 360px;
+  width: 100%;
+}
+
+.search_icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.search_input {
+  width: 100%;
+  padding: 12px 14px 12px 42px;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.search_input:focus {
+  border-color: #78a046;
+  box-shadow: 0 0 0 3px rgba(120, 160, 70, 0.15);
+}
+
+.filters_grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.filter_group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.filter_label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.input {
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  background: #fff;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.input:focus {
+  border-color: #78a046;
+  box-shadow: 0 0 0 3px rgba(120, 160, 70, 0.15);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 16px;
+  }
+
+  .search_wrapper {
+    max-width: 100%;
+  }
+
+  .filters_grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .search_input {
+    padding: 10px 14px 10px 38px;
+    font-size: 13px;
+  }
+
+  .filter_label {
+    font-size: 11px;
+  }
+}

--- a/src/app/leads/analysis/components/leads-filters.tsx
+++ b/src/app/leads/analysis/components/leads-filters.tsx
@@ -1,0 +1,90 @@
+import CustomSelect from "@/components/custom-select/custom-select";
+import DateInput from "./date-input";
+import styles from "./leads-filters.module.css";
+
+type FilterValues = {
+  source: string;
+  neighborhood: string;
+  dateFrom: string;
+  dateTo: string;
+};
+
+type SourceOption = {
+  value: string;
+  label: string;
+};
+
+type LeadsFiltersProps = {
+  search: string;
+  filters: FilterValues;
+  sourceOptions: SourceOption[];
+  onSearchChange: (value: string) => void;
+  onFilterChange: (key: keyof FilterValues, value: string) => void;
+};
+
+const LeadsFilters = ({
+  search,
+  filters,
+  sourceOptions,
+  onSearchChange,
+  onFilterChange,
+}: LeadsFiltersProps) => (
+  <div className={styles.container}>
+    <div className={styles.search_wrapper}>
+      <svg className={styles.search_icon} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#999" strokeWidth="2">
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.35-4.35" />
+      </svg>
+      <input
+        type="text"
+        className={styles.search_input}
+        placeholder="Buscar por nome..."
+        value={search}
+        onChange={(e) => onSearchChange(e.target.value)}
+      />
+    </div>
+
+    <div className={styles.filters_grid}>
+      <div className={styles.filter_group}>
+        <label className={styles.filter_label}>Source</label>
+        <CustomSelect
+          options={sourceOptions}
+          value={filters.source}
+          onChange={(val) => onFilterChange("source", val)}
+          placeholder="Todos"
+        />
+      </div>
+
+      <div className={styles.filter_group}>
+        <label className={styles.filter_label}>Bairro</label>
+        <input
+          type="text"
+          className={styles.input}
+          placeholder="Filtrar bairro..."
+          value={filters.neighborhood}
+          onChange={(e) => onFilterChange("neighborhood", e.target.value)}
+        />
+      </div>
+
+      <div className={styles.filter_group}>
+        <label className={styles.filter_label}>Data inicial</label>
+        <DateInput
+          value={filters.dateFrom}
+          onChange={(val) => onFilterChange("dateFrom", val)}
+          placeholder="Início"
+        />
+      </div>
+
+      <div className={styles.filter_group}>
+        <label className={styles.filter_label}>Data final</label>
+        <DateInput
+          value={filters.dateTo}
+          onChange={(val) => onFilterChange("dateTo", val)}
+          placeholder="Fim"
+        />
+      </div>
+    </div>
+  </div>
+);
+
+export default LeadsFilters;

--- a/src/app/leads/analysis/components/leads-table.module.css
+++ b/src/app/leads/analysis/components/leads-table.module.css
@@ -1,0 +1,252 @@
+.wrapper {
+  position: relative;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  border-radius: 14px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 860px;
+}
+
+.table thead {
+  background: #132e33;
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.table th {
+  padding: 14px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.actions_header {
+  text-align: center;
+}
+
+.table td {
+  padding: 12px 16px;
+  font-size: 13px;
+  color: #333;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.table tbody tr:nth-child(even) {
+  background: #fafbfc;
+}
+
+.table tbody tr:hover {
+  background: #f0f5eb;
+}
+
+.name_cell {
+  font-weight: 500;
+  color: #132e33;
+}
+
+.phone_cell {
+  white-space: nowrap;
+}
+
+.phone_link {
+  color: #25d366;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.phone_link:hover {
+  color: #128c7e;
+  text-decoration: underline;
+}
+
+.email_cell {
+  color: #666;
+}
+
+.date_cell {
+  white-space: nowrap;
+  color: #666;
+  font-size: 12px;
+}
+
+.source_badge {
+  display: inline-block;
+  padding: 3px 8px;
+  background: #f3f4f6;
+  color: #6b7280;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.delete_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  color: #999;
+  transition: all 0.2s;
+  margin: 0 auto;
+}
+
+.delete_button:hover:not(:disabled) {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #dc2626;
+}
+
+.delete_button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 64px 24px;
+}
+
+.empty_title {
+  font-size: 16px;
+  font-weight: 500;
+  color: #555;
+}
+
+.empty_subtitle {
+  font-size: 13px;
+  color: #999;
+}
+
+@media (max-width: 1024px) {
+  .table {
+    min-width: 720px;
+  }
+
+  .table th {
+    padding: 10px 12px;
+  }
+
+  .table td {
+    padding: 10px 12px;
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 768px) {
+  .wrapper {
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .table {
+    min-width: 0;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .table tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .table tbody tr {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+    border: 1px solid #f0f0f0;
+    position: relative;
+  }
+
+  .table tbody tr:nth-child(even) {
+    background: #fff;
+  }
+
+  .table tbody tr:hover {
+    background: #fff;
+  }
+
+  .table td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid #f5f5f5;
+    font-size: 13px;
+  }
+
+  .table td:last-child {
+    border-bottom: none;
+  }
+
+  .table td::before {
+    content: attr(data-label);
+    font-size: 11px;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    min-width: 90px;
+    flex-shrink: 0;
+  }
+
+  .name_cell {
+    font-size: 15px;
+  }
+
+  .phone_cell {
+    white-space: normal;
+  }
+
+  .date_cell {
+    white-space: normal;
+  }
+
+  .table td:last-child::before {
+    display: none;
+  }
+
+  .delete_button {
+    margin: 0;
+    margin-left: auto;
+  }
+
+  .empty {
+    padding: 40px 16px;
+  }
+}

--- a/src/app/leads/analysis/components/leads-table.tsx
+++ b/src/app/leads/analysis/components/leads-table.tsx
@@ -1,0 +1,114 @@
+import { sourceColorMap, sourceLabels } from "../source-config";
+import { formatPhone, formatDate } from "../utils";
+import type { Lead } from "../types";
+import Spinner from "./spinner";
+import styles from "./leads-table.module.css";
+
+type LeadsTableProps = {
+  leads: Lead[];
+  loading: boolean;
+  deletingId: string | null;
+  onDelete: (id: string, name: string) => void;
+};
+
+const TrashIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <line x1="10" y1="11" x2="10" y2="17" />
+    <line x1="14" y1="11" x2="14" y2="17" />
+  </svg>
+);
+
+const LeadsTable = ({
+  leads,
+  loading,
+  deletingId,
+  onDelete,
+}: LeadsTableProps) => (
+  <div className={styles.wrapper}>
+    {loading && (
+      <div className={styles.overlay}>
+        <Spinner size="md" />
+      </div>
+    )}
+
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Nome</th>
+          <th>Telefone</th>
+          <th>E-mail</th>
+          <th>Bairro</th>
+          <th>Necessidade</th>
+          <th>Source</th>
+          <th>Data</th>
+          <th className={styles.actions_header}>Ações</th>
+        </tr>
+      </thead>
+      <tbody>
+        {leads.map((lead) => (
+          <tr key={lead.id}>
+            <td data-label="Nome" className={styles.name_cell}>{lead.full_name}</td>
+            <td data-label="Telefone" className={styles.phone_cell}>
+              {(() => {
+                const parsed = formatPhone(lead.phone);
+                if (parsed) {
+                  return (
+                    <a
+                      href={parsed.whatsappUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.phone_link}
+                      title="Abrir WhatsApp"
+                    >
+                      {parsed.formatted}
+                    </a>
+                  );
+                }
+                return <span>{lead.phone}</span>;
+              })()}
+            </td>
+            <td data-label="E-mail" className={styles.email_cell}>{lead.email || "—"}</td>
+            <td data-label="Bairro">{lead.neighborhood}</td>
+            <td data-label="Necessidade">{lead.need}</td>
+            <td data-label="Source">
+              <span
+                className={styles.source_badge}
+                style={sourceColorMap[lead.source] || undefined}
+              >
+                {sourceLabels[lead.source] || lead.source}
+              </span>
+            </td>
+            <td data-label="Data" className={styles.date_cell}>{formatDate(lead.created_at)}</td>
+            <td data-label="Ações">
+              <button
+                type="button"
+                className={styles.delete_button}
+                disabled={deletingId === lead.id}
+                onClick={() => onDelete(lead.id, lead.full_name)}
+                title="Deletar lead"
+              >
+                <TrashIcon />
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+
+    {leads.length === 0 && !loading && (
+      <div className={styles.empty}>
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#bbb" strokeWidth="1.5">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="9" y1="15" x2="15" y2="15" />
+        </svg>
+        <h3 className={styles.empty_title}>Nenhum lead encontrado</h3>
+        <p className={styles.empty_subtitle}>Tente ajustar os filtros ou a busca</p>
+      </div>
+    )}
+  </div>
+);
+
+export default LeadsTable;

--- a/src/app/leads/analysis/components/pagination.module.css
+++ b/src/app/leads/analysis/components/pagination.module.css
@@ -1,0 +1,73 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.range {
+  font-size: 13px;
+  color: #666;
+}
+
+.buttons {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: #fff;
+  color: #333;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  background: #f0f5eb;
+  border-color: #78a046;
+  color: #4a7025;
+}
+
+.button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.page_info {
+  font-size: 13px;
+  font-weight: 500;
+  color: #333;
+}
+
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .range {
+    font-size: 12px;
+    text-align: center;
+  }
+
+  .buttons {
+    gap: 8px;
+  }
+
+  .button {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
+}

--- a/src/app/leads/analysis/components/pagination.tsx
+++ b/src/app/leads/analysis/components/pagination.tsx
@@ -1,0 +1,60 @@
+import styles from "./pagination.module.css";
+
+type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+};
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  totalCount,
+  pageSize,
+  onPageChange,
+}: PaginationProps) => {
+  if (totalPages <= 1) return null;
+
+  const from = (currentPage - 1) * pageSize + 1;
+  const to = Math.min(currentPage * pageSize, totalCount);
+
+  return (
+    <div className={styles.container}>
+      <span className={styles.range}>
+        Mostrando {from}–{to} de {totalCount}
+      </span>
+
+      <div className={styles.buttons}>
+        <button
+          className={styles.button}
+          disabled={currentPage === 1}
+          onClick={() => onPageChange(currentPage - 1)}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          Anterior
+        </button>
+
+        <span className={styles.page_info}>
+          {currentPage} / {totalPages}
+        </span>
+
+        <button
+          className={styles.button}
+          disabled={currentPage === totalPages}
+          onClick={() => onPageChange(currentPage + 1)}
+        >
+          Próxima
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/app/leads/analysis/components/spinner.module.css
+++ b/src/app/leads/analysis/components/spinner.module.css
@@ -1,0 +1,14 @@
+.spinner {
+  width: var(--spinner-size, 32px);
+  height: var(--spinner-size, 32px);
+  border: 3px solid #e0e0e0;
+  border-top-color: #78a046;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/leads/analysis/components/spinner.tsx
+++ b/src/app/leads/analysis/components/spinner.tsx
@@ -1,0 +1,16 @@
+import styles from "./spinner.module.css";
+
+type SpinnerProps = {
+  size?: "sm" | "md" | "lg";
+};
+
+const sizeMap = { sm: "20px", md: "32px", lg: "48px" };
+
+const Spinner = ({ size = "md" }: SpinnerProps) => (
+  <div
+    className={styles.spinner}
+    style={{ "--spinner-size": sizeMap[size] } as React.CSSProperties}
+  />
+);
+
+export default Spinner;

--- a/src/app/leads/analysis/page.module.css
+++ b/src/app/leads/analysis/page.module.css
@@ -1,0 +1,103 @@
+.container {
+  min-height: 100vh;
+  padding: 32px 28px;
+  background: #e7ecec;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.header_left {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.landing_link {
+  padding: 8px 16px;
+  background: #fff;
+  color: #132e33;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.landing_link:hover {
+  background: #f0f5eb;
+  border-color: #78a046;
+  color: #4a7025;
+}
+
+.title {
+  font-size: 26px;
+  font-weight: 500;
+  color: #132e33;
+}
+
+.count {
+  font-size: 14px;
+  color: #666;
+  background: #fff;
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1px solid #e0e0e0;
+}
+
+.table_scroll {
+  overflow-x: auto;
+  border-radius: 14px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 16px 12px;
+  }
+
+  .header {
+    flex-direction: column;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  .title {
+    font-size: 22px;
+  }
+
+  .landing_link {
+    width: 100%;
+    text-align: center;
+  }
+
+  .table_scroll {
+    overflow-x: visible;
+    border-radius: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 12px 8px;
+  }
+
+  .title {
+    font-size: 18px;
+  }
+
+  .count {
+    font-size: 12px;
+    padding: 3px 8px;
+  }
+}

--- a/src/app/leads/analysis/page.tsx
+++ b/src/app/leads/analysis/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { sourceOptions } from "./source-config";
+import useLeadsAnalysis, { PAGE_SIZE } from "./use-leads-analysis";
+import AuthGate from "./components/auth-gate";
+import LeadsFilters from "./components/leads-filters";
+import LeadsTable from "./components/leads-table";
+import Pagination from "./components/pagination";
+import styles from "./page.module.css";
+
+export default function LeadsAnalysisPage() {
+  const {
+    authenticated,
+    authLoading,
+    authError,
+    leads,
+    totalCount,
+    currentPage,
+    totalPages,
+    loading,
+    search,
+    filters,
+    deletingId,
+    handleLogin,
+    setSearch,
+    handleFilterChange,
+    handleDelete,
+    setCurrentPage,
+  } = useLeadsAnalysis();
+
+  if (!authenticated) {
+    return (
+      <AuthGate
+        onSubmit={handleLogin}
+        error={authError}
+        loading={authLoading}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <div className={styles.header_left}>
+          <h1 className={styles.title}>Análise de Leads</h1>
+          <span className={styles.count}>{totalCount} leads encontrados</span>
+        </div>
+        <a href="/" className={styles.landing_link}>
+          Ir para a landing page
+        </a>
+      </header>
+
+      <LeadsFilters
+        search={search}
+        filters={filters}
+        sourceOptions={sourceOptions}
+        onSearchChange={setSearch}
+        onFilterChange={handleFilterChange}
+      />
+
+      <div className={styles.table_scroll}>
+        <LeadsTable
+          leads={leads}
+          loading={loading}
+          deletingId={deletingId}
+          onDelete={handleDelete}
+        />
+      </div>
+
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalCount={totalCount}
+        pageSize={PAGE_SIZE}
+        onPageChange={setCurrentPage}
+      />
+    </div>
+  );
+}

--- a/src/app/leads/analysis/source-config.ts
+++ b/src/app/leads/analysis/source-config.ts
@@ -1,0 +1,22 @@
+import { FormSources } from "@/modules/constants";
+
+const SOURCE_DISPLAY: Record<string, string> = {
+  TESTES: "Testes",
+  REDE_DE_PESQUISA: "Rede de Pesquisa",
+  P_MAX: "P-Max",
+};
+
+export const sourceLabels: Record<number, string> = Object.fromEntries(
+  Object.entries(FormSources).map(([key, value]) => [value, SOURCE_DISPLAY[key] || key])
+);
+
+export const sourceOptions = Object.entries(FormSources).map(([key, value]) => ({
+  value: String(value),
+  label: SOURCE_DISPLAY[key] || key,
+}));
+
+export const sourceColorMap: Record<number, { color: string; background: string }> = {
+  [FormSources.TESTES]: { color: "#6b7280", background: "#f3f4f6" },
+  [FormSources.REDE_DE_PESQUISA]: { color: "#1d4ed8", background: "#eff6ff" },
+  [FormSources.P_MAX]: { color: "#7c3aed", background: "#f5f3ff" },
+};

--- a/src/app/leads/analysis/types.ts
+++ b/src/app/leads/analysis/types.ts
@@ -1,0 +1,17 @@
+export type Lead = {
+  id: string;
+  created_at: string;
+  source: number;
+  full_name: string;
+  phone: string;
+  email: string | null;
+  neighborhood: string;
+  need: string;
+};
+
+export type Filters = {
+  source: string;
+  neighborhood: string;
+  dateFrom: string;
+  dateTo: string;
+};

--- a/src/app/leads/analysis/use-leads-analysis.ts
+++ b/src/app/leads/analysis/use-leads-analysis.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Lead, Filters } from "./types";
+
+const STORAGE_KEY = "ADMIN_PASSWORD";
+const PAGE_SIZE = 50;
+
+export default function useLeadsAnalysis() {
+  const [password, setPassword] = useState("");
+  const [authError, setAuthError] = useState("");
+  const [authenticated, setAuthenticated] = useState(false);
+  const [authLoading, setAuthLoading] = useState(true);
+
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const [search, setSearch] = useState("");
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>({
+    source: "",
+    neighborhood: "",
+    dateFrom: "",
+    dateTo: "",
+  });
+
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      setPassword(stored);
+    } else {
+      setAuthLoading(false);
+    }
+  }, []);
+
+  const fetchLeads = useCallback(
+    async (pwd: string, page: number, searchTerm: string, f: Filters) => {
+      setLoading(true);
+      const params = new URLSearchParams();
+      params.set("page", String(page));
+      if (searchTerm) params.set("search", searchTerm);
+      if (f.source) params.set("source", f.source);
+      if (f.neighborhood) params.set("neighborhood", f.neighborhood);
+      if (f.dateFrom) params.set("date_from", f.dateFrom);
+      if (f.dateTo) params.set("date_to", f.dateTo);
+
+      const res = await fetch(`/api/leads?${params.toString()}`, {
+        headers: { "x-admin-password": pwd },
+      });
+
+      if (res.status === 401) {
+        setAuthenticated(false);
+        setAuthError("Senha incorreta.");
+        localStorage.removeItem(STORAGE_KEY);
+        setLoading(false);
+        setAuthLoading(false);
+        return;
+      }
+
+      const json = await res.json();
+      if (!res.ok) {
+        setLoading(false);
+        setAuthLoading(false);
+        return;
+      }
+
+      setAuthenticated(true);
+      setAuthError("");
+      setLeads(json.data || []);
+      setTotalCount(json.count || 0);
+      setLoading(false);
+      setAuthLoading(false);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (password) {
+      fetchLeads(password, currentPage, search, filters);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [password, currentPage, filters]);
+
+  useEffect(() => {
+    if (!password) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setCurrentPage(1);
+      fetchLeads(password, 1, search, filters);
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  const handleLogin = (pwd: string) => {
+    localStorage.setItem(STORAGE_KEY, pwd);
+    setPassword(pwd);
+    setAuthLoading(true);
+  };
+
+  const handleFilterChange = (key: keyof Filters, value: string) => {
+    setCurrentPage(1);
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleDelete = async (id: string, name: string) => {
+    if (!window.confirm(`Deletar o lead "${name}"?`)) return;
+    setDeletingId(id);
+
+    const res = await fetch("/api/leads", {
+      method: "DELETE",
+      headers: {
+        "x-admin-password": password,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id }),
+    });
+
+    if (res.ok) {
+      setLeads((prev) => prev.filter((l) => l.id !== id));
+      setTotalCount((prev) => prev - 1);
+    }
+
+    setDeletingId(null);
+  };
+
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+  return {
+    authenticated,
+    authLoading,
+    authError,
+    leads,
+    totalCount,
+    currentPage,
+    totalPages,
+    loading,
+    search,
+    filters,
+    deletingId,
+    handleLogin,
+    setSearch,
+    handleFilterChange,
+    handleDelete,
+    setCurrentPage,
+  };
+}
+
+export { PAGE_SIZE };

--- a/src/app/leads/analysis/utils.ts
+++ b/src/app/leads/analysis/utils.ts
@@ -1,0 +1,27 @@
+export const formatPhone = (raw: string): { formatted: string; whatsappUrl: string } | null => {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length < 10 || digits.length > 13) return null;
+
+  const national = digits.startsWith("55") ? digits.slice(2) : digits;
+  if (national.length < 10 || national.length > 11) return null;
+
+  const ddd = national.slice(0, 2);
+  const number = national.slice(2);
+  const formatted =
+    number.length === 9
+      ? `(${ddd}) ${number.slice(0, 5)}-${number.slice(5)}`
+      : `(${ddd}) ${number.slice(0, 4)}-${number.slice(4)}`;
+
+  return { formatted, whatsappUrl: `https://wa.me/55${national}` };
+};
+
+export const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};

--- a/src/app/leads/layout.tsx
+++ b/src/app/leads/layout.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from "react";
+
+export default function LeadsLayout({ children }: PropsWithChildren) {
+  return <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>{children}</div>;
+}

--- a/src/components/body-wrapper/body-wrapper.tsx
+++ b/src/components/body-wrapper/body-wrapper.tsx
@@ -1,17 +1,26 @@
 import { PropsWithChildren } from "react";
-import { Poppins } from "next/font/google";
-
+import { CtaMode } from "@/modules/constants";
 import Navbar from "../navbar/navbar";
 import Footer from "../footer/footer";
+import ClientProviders from "./client-providers";
 
-const poppins = Poppins({ subsets: ["latin"], weight: ["300", "400", "500"] });
+type BodyWrapperProps = PropsWithChildren<{
+  ctaMode?: CtaMode;
+  defaultSource?: number;
+  isLeadsterCTA?: boolean;
+}>;
 
-const BodyWrapper = ({ children }: PropsWithChildren) => (
-  <body className={poppins.className} suppressHydrationWarning={true}>
-    <Navbar isLeadsterCTA={false} />
+const BodyWrapper = ({
+  children,
+  ctaMode,
+  defaultSource,
+  isLeadsterCTA = false,
+}: BodyWrapperProps) => (
+  <ClientProviders ctaMode={ctaMode} defaultSource={defaultSource}>
+    <Navbar isLeadsterCTA={isLeadsterCTA} />
     {children}
     <Footer />
-  </body>
+  </ClientProviders>
 );
 
 export default BodyWrapper;

--- a/src/components/body-wrapper/client-providers.tsx
+++ b/src/components/body-wrapper/client-providers.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { PropsWithChildren } from "react";
+import { LeadModalProvider } from "@/contexts/lead-modal-context";
+import { CtaMode } from "@/modules/constants";
+import LeadModal from "../lead-modal/lead-modal";
+import IntentModal from "../intent-modal/intent-modal";
+
+type ClientProvidersProps = PropsWithChildren<{
+  ctaMode?: CtaMode;
+  defaultSource?: number;
+}>;
+
+const ClientProviders = ({
+  children,
+  ctaMode,
+  defaultSource,
+}: ClientProvidersProps) => (
+  <LeadModalProvider ctaMode={ctaMode} defaultSource={defaultSource}>
+    {children}
+    <IntentModal />
+    <LeadModal />
+  </LeadModalProvider>
+);
+
+export default ClientProviders;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -6,6 +6,7 @@ import {
   whatsAppDefaultLink,
 } from "@/modules/constants";
 import { sendGTMEvent } from "@next/third-parties/google";
+import { useLeadModal } from "@/contexts/lead-modal-context";
 
 import styles from "./button.module.css";
 
@@ -19,6 +20,7 @@ export type ButtonProps = {
   skipAnalytics?: boolean;
   backgroundHover?: string;
   useAlternativeLink?: boolean;
+  source?: number;
 };
 
 const Button = ({
@@ -32,7 +34,12 @@ const Button = ({
   backgroundHover,
   useAlternativeLink,
   skipAnalytics = false,
+  source,
 }: PropsWithChildren<ButtonProps>) => {
+  const { openIntentModal, defaultSource } = useLeadModal();
+
+  const resolvedSource = source ?? defaultSource;
+
   const buttonStyle: CSSProperties = {
     "--button-width": width,
     "--button-height": height,
@@ -41,23 +48,47 @@ const Button = ({
     "--button-background-hover": backgroundHover,
   } as React.CSSProperties;
 
+  const whatsappUrl = useMemo(
+    () => (useAlternativeLink ? whatsAppAlternativeLink : whatsAppDefaultLink),
+    [useAlternativeLink]
+  );
+
+  const isWhatsAppCTA = !isLeadsterCTA && !customHref;
+
   const href = useMemo(() => {
     if (isLeadsterCTA) return undefined;
     if (customHref) return customHref;
+    return undefined;
+  }, [isLeadsterCTA, customHref]);
 
-    return useAlternativeLink ? whatsAppAlternativeLink : whatsAppDefaultLink;
-  }, [isLeadsterCTA, customHref, useAlternativeLink]);
+  const handleClick = () => {
+    if (isWhatsAppCTA) {
+      if (!skipAnalytics) {
+        if (useAlternativeLink) {
+          window.gtag_report_conversion();
+        } else {
+          sendGTMEvent({ event: "clickWhatsapp", value: "click" });
+        }
+      }
+      openIntentModal(resolvedSource, whatsappUrl);
+      return;
+    }
 
-  const Button = (
+    if (skipAnalytics) return;
+    if (useAlternativeLink) return window.gtag_report_conversion();
+    sendGTMEvent({ event: "clickWhatsapp", value: "click" });
+  };
+
+  const ButtonEl = (
     <a
       className={styles.button}
       style={buttonStyle}
       href={href}
-      onClick={() => {
-        if (skipAnalytics) return;
-        if (useAlternativeLink) return window.gtag_report_conversion();
-
-        sendGTMEvent({ event: "clickWhatsapp", value: "click" });
+      onClick={(e) => {
+        if (isWhatsAppCTA) {
+          e.preventDefault();
+        }
+        handleClick();
       }}
     >
       {children}
@@ -65,10 +96,10 @@ const Button = ({
   );
 
   if (isLeadsterCTA) {
-    return <div className="leadster-cta">{Button}</div>;
+    return <div className="leadster-cta">{ButtonEl}</div>;
   }
 
-  return Button;
+  return ButtonEl;
 };
 
 export default Button;

--- a/src/components/custom-select/custom-select.module.css
+++ b/src/components/custom-select/custom-select.module.css
@@ -1,0 +1,97 @@
+.wrapper {
+  position: relative;
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 40px;
+  padding: 0 12px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  text-align: left;
+}
+
+.trigger:hover {
+  border-color: #ccc;
+}
+
+.trigger_open {
+  border-color: #78a046;
+  box-shadow: 0 0 0 3px rgba(120, 160, 70, 0.15);
+}
+
+.trigger_error {
+  border-color: #d32f2f;
+}
+
+.trigger_text {
+  color: #333;
+}
+
+.trigger_placeholder {
+  color: #999;
+}
+
+.chevron {
+  color: #666;
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+
+.chevron_open {
+  transform: rotate(180deg);
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  z-index: 50;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 4px;
+  animation: dropIn 0.15s ease-out;
+}
+
+@keyframes dropIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.option {
+  padding: 10px 12px;
+  font-size: 13px;
+  color: #333;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.option:hover {
+  background: #f0f5eb;
+}
+
+.option_selected {
+  background: #f0f5eb;
+  color: #4a7025;
+  font-weight: 500;
+}

--- a/src/components/custom-select/custom-select.tsx
+++ b/src/components/custom-select/custom-select.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from "react";
+import styles from "./custom-select.module.css";
+
+type Option = {
+  value: string;
+  label: string;
+};
+
+type CustomSelectProps = {
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  hasError?: boolean;
+};
+
+const CustomSelect = ({
+  options,
+  value,
+  onChange,
+  placeholder = "Selecionar...",
+  hasError = false,
+}: CustomSelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const selectedLabel = options.find((o) => o.value === value)?.label || placeholder;
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelect = (optValue: string) => {
+    onChange(optValue);
+    setIsOpen(false);
+  };
+
+  const triggerClass = [
+    styles.trigger,
+    isOpen ? styles.trigger_open : "",
+    hasError ? styles.trigger_error : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={styles.wrapper} ref={ref}>
+      <button
+        type="button"
+        className={triggerClass}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span className={value ? styles.trigger_text : styles.trigger_placeholder}>
+          {selectedLabel}
+        </span>
+        <svg
+          className={`${styles.chevron} ${isOpen ? styles.chevron_open : ""}`}
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className={styles.dropdown}>
+          {options.map((opt) => (
+            <div
+              key={opt.value}
+              className={`${styles.option} ${opt.value === value ? styles.option_selected : ""}`}
+              onClick={() => handleSelect(opt.value)}
+            >
+              {opt.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CustomSelect;

--- a/src/components/intent-modal/intent-modal.module.css
+++ b/src/components/intent-modal/intent-modal.module.css
@@ -1,0 +1,215 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 16px;
+}
+
+.modal {
+  position: relative;
+  width: 100%;
+  max-width: 440px;
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 36px 28px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  animation: slideUp 0.2s ease-out;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.close_button {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 28px;
+  color: #666;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.close_button:hover {
+  color: #333;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 500;
+  color: #132e33;
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 20px;
+  background: #fafbfc;
+  border: 1px solid #e8e8e8;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+  font-family: inherit;
+}
+
+.card:hover {
+  background: #f0f5eb;
+  border-color: #78a046;
+  box-shadow: 0 4px 12px rgba(120, 160, 70, 0.12);
+  transform: translateY(-1px);
+}
+
+.card_icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid #e8e8e8;
+  flex-shrink: 0;
+}
+
+.card:hover .card_icon {
+  border-color: #c5ddb0;
+  background: #fff;
+}
+
+.card_text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.card_title {
+  font-size: 15px;
+  font-weight: 500;
+  color: #132e33;
+}
+
+.card_subtitle {
+  font-size: 13px;
+  color: #666;
+}
+
+.card_arrow {
+  color: #bbb;
+  flex-shrink: 0;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.card:hover .card_arrow {
+  color: #78a046;
+  transform: translateX(2px);
+}
+
+/* Caregiver step */
+
+.caregiver_content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.caregiver_icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 80px;
+  background: #f0f5eb;
+  border-radius: 50%;
+}
+
+.caregiver_text {
+  font-size: 15px;
+  color: #555;
+  line-height: 1.6;
+  max-width: 340px;
+}
+
+.caregiver_button {
+  display: inline-block;
+  padding: 14px 32px;
+  background: #f18721;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 500;
+  font-family: inherit;
+  border: none;
+  border-radius: 32px;
+  cursor: pointer;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  transition: background 0.2s;
+  margin-top: 4px;
+}
+
+.caregiver_button:hover {
+  background: #c56d1b;
+}
+
+.back_button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 6px;
+  transition: color 0.2s, background 0.2s;
+  margin-top: 4px;
+}
+
+.back_button:hover {
+  color: #333;
+  background: #f0f0f0;
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 28px 20px;
+  }
+
+  .card {
+    padding: 16px;
+  }
+
+  .card_icon {
+    width: 44px;
+    height: 44px;
+  }
+}

--- a/src/components/intent-modal/intent-modal.tsx
+++ b/src/components/intent-modal/intent-modal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useLeadModal } from "@/contexts/lead-modal-context";
+import { workWithUsLink } from "@/modules/constants";
+import styles from "./intent-modal.module.css";
+
+const IntentModal = () => {
+  const { state, goToIntent, goToLeadForm, goToCaregiver, closeModal } = useLeadModal();
+
+  if (state.step !== "intent" && state.step !== "caregiver") return null;
+
+  const handleOverlayClick = () => closeModal();
+
+  if (state.step === "caregiver") {
+    return (
+      <div className={styles.overlay} onClick={handleOverlayClick}>
+        <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            className={styles.close_button}
+            onClick={closeModal}
+            aria-label="Fechar"
+          >
+            &times;
+          </button>
+
+          <div className={styles.caregiver_content}>
+            <div className={styles.caregiver_icon}>
+              <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#78a046" strokeWidth="1.5">
+                <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+              </svg>
+            </div>
+
+            <h2 className={styles.title}>Processo Seletivo</h2>
+            <p className={styles.caregiver_text}>
+              Para participar do nosso processo seletivo, clique no botão abaixo
+              e siga nosso processo de recrutamento.
+            </p>
+
+            <a
+              href={workWithUsLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.caregiver_button}
+              onClick={closeModal}
+            >
+              Participar do processo seletivo
+            </a>
+
+            <button
+              type="button"
+              className={styles.back_button}
+              onClick={goToIntent}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+              Voltar
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.overlay} onClick={handleOverlayClick}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          className={styles.close_button}
+          onClick={closeModal}
+          aria-label="Fechar"
+        >
+          &times;
+        </button>
+
+        <h2 className={styles.title}>Qual o seu objetivo?</h2>
+
+        <div className={styles.cards}>
+          <button
+            type="button"
+            className={styles.card}
+            onClick={goToLeadForm}
+          >
+            <div className={styles.card_icon}>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#78a046" strokeWidth="1.5">
+                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+              </svg>
+            </div>
+            <div className={styles.card_text}>
+              <span className={styles.card_title}>Busco um cuidado</span>
+              <span className={styles.card_subtitle}>
+                Para um familiar ou para mim
+              </span>
+            </div>
+            <svg className={styles.card_arrow} width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+
+          <button
+            type="button"
+            className={styles.card}
+            onClick={goToCaregiver}
+          >
+            <div className={styles.card_icon}>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#78a046" strokeWidth="1.5">
+                <rect x="2" y="7" width="20" height="14" rx="2" />
+                <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
+                <line x1="12" y1="12" x2="12" y2="16" />
+                <line x1="10" y1="14" x2="14" y2="14" />
+              </svg>
+            </div>
+            <div className={styles.card_text}>
+              <span className={styles.card_title}>Sou cuidador(a)</span>
+              <span className={styles.card_subtitle}>
+                Busco oportunidades de trabalho
+              </span>
+            </div>
+            <svg className={styles.card_arrow} width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IntentModal;

--- a/src/components/lead-modal/lead-modal.module.css
+++ b/src/components/lead-modal/lead-modal.module.css
@@ -1,0 +1,139 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 16px;
+}
+
+.modal {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  max-height: 90vh;
+  overflow-y: auto;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 32px 28px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.close_button {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 28px;
+  color: #666;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.close_button:hover {
+  color: #333;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 500;
+  color: #132e33;
+  margin-bottom: 4px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 24px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.field input {
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  background: #fff;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.field input:focus {
+  border-color: #78a046;
+  box-shadow: 0 0 0 3px rgba(120, 160, 70, 0.15);
+}
+
+.input_error {
+  border-color: #d32f2f !important;
+}
+
+.input_error:focus {
+  box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.15) !important;
+}
+
+.error {
+  font-size: 12px;
+  color: #d32f2f;
+}
+
+.submit_error {
+  font-size: 14px;
+  color: #d32f2f;
+  text-align: center;
+}
+
+.submit_button {
+  width: 100%;
+  padding: 14px;
+  background: #f18721;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: inherit;
+  border: none;
+  border-radius: 32px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: background 0.2s;
+}
+
+.submit_button:hover:not(:disabled) {
+  background: #c56d1b;
+}
+
+.submit_button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+@media (max-width: 480px) {
+  .modal {
+    padding: 24px 20px;
+  }
+
+  .title {
+    font-size: 20px;
+  }
+}

--- a/src/components/lead-modal/lead-modal.tsx
+++ b/src/components/lead-modal/lead-modal.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { useLeadModal } from "@/contexts/lead-modal-context";
+import { createClient } from "@/utils/supabase/client";
+import { buildWhatsAppUrl } from "@/modules/constants";
+import CustomSelect from "@/components/custom-select/custom-select";
+import styles from "./lead-modal.module.css";
+
+type LeadFormData = {
+  fullName: string;
+  phone: string;
+  email: string;
+  neighborhood: string;
+  need: string;
+};
+
+const needOptions = [
+  { value: "Obter um orçamento", label: "Obter um orçamento" },
+  { value: "Tirar dúvidas", label: "Tirar dúvidas" },
+];
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const formatPhoneInput = (value: string): string => {
+  const digits = value.replace(/\D/g, "").slice(0, 11);
+  if (digits.length === 0) return "";
+  if (digits.length <= 2) return `(${digits}`;
+  if (digits.length <= 7) return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+  if (digits.length <= 10)
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+};
+
+const LeadModal = () => {
+  const { state, ctaMode, closeModal } = useLeadModal();
+  const [loading, setLoading] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+
+  const isSimplified = ctaMode === "lead-only";
+
+  const supabase = useMemo(() => createClient(), []);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm<LeadFormData>();
+
+  const onSubmit = async (data: LeadFormData) => {
+    setLoading(true);
+    setSubmitError("");
+
+    const { error } = await supabase.from("leads").insert({
+      source: state.source,
+      full_name: data.fullName,
+      phone: data.phone,
+      email: isSimplified ? null : data.email || null,
+      neighborhood: isSimplified ? "Não informado" : data.neighborhood,
+      need: isSimplified ? "Obter um orçamento" : data.need,
+    });
+
+    if (error) {
+      setSubmitError("Erro ao enviar. Por favor, tente novamente.");
+      setLoading(false);
+      return;
+    }
+
+    let whatsappUrl: string;
+    if (isSimplified) {
+      whatsappUrl = buildWhatsAppUrl(
+        "Olá, Gostaria de mais informações sobre os serviços da Acuidar"
+      );
+    } else {
+      whatsappUrl = buildWhatsAppUrl(
+        `Olá, meu nome é ${data.fullName} e gostaria de informações sobre os serviços da Acuidar`
+      );
+    }
+
+    setLoading(false);
+    reset();
+    window.open(whatsappUrl, "_blank");
+    closeModal();
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    reset();
+    setSubmitError("");
+    closeModal();
+  };
+
+  if (state.step !== "lead-form") return null;
+
+  return (
+    <div className={styles.overlay} onClick={handleClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          className={styles.close_button}
+          onClick={handleClose}
+          aria-label="Fechar"
+        >
+          &times;
+        </button>
+
+        <h2 className={styles.title}>Fale conosco</h2>
+        <p className={styles.subtitle}>
+          Preencha seus dados para entrarmos em contato
+        </p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+          <div className={styles.field}>
+            <label htmlFor="fullName">Nome Completo *</label>
+            <input
+              id="fullName"
+              type="text"
+              placeholder="Seu nome completo"
+              className={errors.fullName ? styles.input_error : ""}
+              {...register("fullName", { required: "Nome é obrigatório" })}
+            />
+            {errors.fullName && (
+              <span className={styles.error}>{errors.fullName.message}</span>
+            )}
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="phone">WhatsApp / Telefone *</label>
+            <Controller
+              name="phone"
+              control={control}
+              rules={{
+                required: "Telefone é obrigatório",
+                validate: (val) => {
+                  const digits = val.replace(/\D/g, "");
+                  return digits.length >= 10 || "Formato inválido. Ex: (11) 99999-9999";
+                },
+              }}
+              render={({ field }) => (
+                <input
+                  id="phone"
+                  type="tel"
+                  inputMode="numeric"
+                  autoComplete="tel"
+                  placeholder="(11) 99999-9999"
+                  className={errors.phone ? styles.input_error : ""}
+                  value={field.value || ""}
+                  onChange={(e) => field.onChange(formatPhoneInput(e.target.value))}
+                />
+              )}
+            />
+            {errors.phone && (
+              <span className={styles.error}>{errors.phone.message}</span>
+            )}
+          </div>
+
+          {!isSimplified && (
+            <>
+              <div className={styles.field}>
+                <label htmlFor="email">E-mail</label>
+                <input
+                  id="email"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  placeholder="seu@email.com"
+                  className={errors.email ? styles.input_error : ""}
+                  {...register("email", {
+                    pattern: {
+                      value: EMAIL_PATTERN,
+                      message: "E-mail inválido",
+                    },
+                  })}
+                />
+                {errors.email && (
+                  <span className={styles.error}>{errors.email.message}</span>
+                )}
+              </div>
+
+              <div className={styles.field}>
+                <label htmlFor="neighborhood">Bairro *</label>
+                <input
+                  id="neighborhood"
+                  type="text"
+                  placeholder="Seu bairro"
+                  className={errors.neighborhood ? styles.input_error : ""}
+                  {...register("neighborhood", {
+                    required: "Bairro é obrigatório",
+                  })}
+                />
+                {errors.neighborhood && (
+                  <span className={styles.error}>
+                    {errors.neighborhood.message}
+                  </span>
+                )}
+              </div>
+
+              <div className={styles.field}>
+                <label>Necessidade *</label>
+                <Controller
+                  name="need"
+                  control={control}
+                  rules={{ required: "Selecione uma opção" }}
+                  render={({ field }) => (
+                    <CustomSelect
+                      options={needOptions}
+                      value={field.value || ""}
+                      onChange={field.onChange}
+                      placeholder="Selecione..."
+                      hasError={!!errors.need}
+                    />
+                  )}
+                />
+                {errors.need && (
+                  <span className={styles.error}>{errors.need.message}</span>
+                )}
+              </div>
+            </>
+          )}
+
+          {submitError && (
+            <p className={styles.submit_error}>{submitError}</p>
+          )}
+
+          <button
+            type="submit"
+            className={styles.submit_button}
+            disabled={loading}
+          >
+            {loading ? "Enviando..." : "Enviar e ir para WhatsApp"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default LeadModal;

--- a/src/components/navbar/navbar.module.css
+++ b/src/components/navbar/navbar.module.css
@@ -27,3 +27,12 @@
     display: none;
   }
 }
+
+.whatsapp_icon_button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,50 +1,68 @@
+"use client";
+
 import Image from "next/image";
 
 import Button from "../button/button";
 import styles from "./navbar.module.css";
 import { whatsAppDefaultLink } from "@/modules/constants";
- type NavbarProps = {
-  isLeadsterCTA?: boolean;
- }
+import { useLeadModal } from "@/contexts/lead-modal-context";
 
-const Navbar = ({ isLeadsterCTA }: NavbarProps) => (
-  <nav className={styles.navbar}>
-    <Image
-      alt="Logo Acuidar"
-      src="/logo.svg"
-      width={120}
-      height={45}
-      priority
-    />
-    <div className={styles.whatsapp_cta}>
-      {isLeadsterCTA ? (
-        <div className="leadster-cta">
-          <Image
-            alt="Whatsapp"
-            src="/whatsapp.svg"
-            width={48}
-            height={48}
-            priority
-          />
+type NavbarProps = {
+  isLeadsterCTA?: boolean;
+};
+
+const Navbar = ({ isLeadsterCTA }: NavbarProps) => {
+  const { openIntentModal, defaultSource } = useLeadModal();
+
+  return (
+    <nav className={styles.navbar}>
+      <Image
+        alt="Logo Acuidar"
+        src="/logo.svg"
+        width={120}
+        height={45}
+        priority
+      />
+      <div className={styles.whatsapp_cta}>
+        {isLeadsterCTA ? (
+          <div className="leadster-cta">
+            <Image
+              alt="Whatsapp"
+              src="/whatsapp.svg"
+              width={48}
+              height={48}
+              priority
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={styles.whatsapp_icon_button}
+            onClick={() =>
+              openIntentModal(defaultSource, whatsAppDefaultLink)
+            }
+          >
+            <Image
+              alt="Whatsapp"
+              src="/whatsapp.svg"
+              width={48}
+              height={48}
+              priority
+            />
+          </button>
+        )}
+        <div className={styles.whatsapp_button}>
+          <Button
+            isLeadsterCTA={isLeadsterCTA}
+            width="220px"
+            fontSize="14px"
+          >
+            Solicite um cuidador
+          </Button>
         </div>
-      ) : (
-        <a href={whatsAppDefaultLink}>
-          <Image
-            alt="Whatsapp"
-            src="/whatsapp.svg"
-            width={48}
-            height={48}
-            priority
-          />
-        </a>
-      )}
-      <div className={styles.whatsapp_button}>
-        <Button isLeadsterCTA={isLeadsterCTA} width="220px" fontSize="14px">
-          Solicite um cuidador
-        </Button>
       </div>
-    </div>
-  </nav>
-);
+    </nav>
+  );
+};
 
 export default Navbar;

--- a/src/contexts/lead-modal-context.tsx
+++ b/src/contexts/lead-modal-context.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  PropsWithChildren,
+} from "react";
+import { FormSources, CtaMode } from "@/modules/constants";
+
+type ModalStep = "closed" | "intent" | "lead-form" | "caregiver";
+
+type LeadModalState = {
+  step: ModalStep;
+  source: number;
+  whatsappUrl: string;
+};
+
+type LeadModalContextValue = {
+  state: LeadModalState;
+  ctaMode: CtaMode;
+  defaultSource: number;
+  openIntentModal: (source: number, whatsappUrl: string) => void;
+  goToIntent: () => void;
+  goToLeadForm: () => void;
+  goToCaregiver: () => void;
+  closeModal: () => void;
+};
+
+const LeadModalContext = createContext<LeadModalContextValue | null>(null);
+
+type LeadModalProviderProps = PropsWithChildren<{
+  ctaMode?: CtaMode;
+  defaultSource?: number;
+}>;
+
+export const LeadModalProvider = ({
+  children,
+  ctaMode = "full",
+  defaultSource = FormSources.TESTES,
+}: LeadModalProviderProps) => {
+  const [state, setState] = useState<LeadModalState>({
+    step: "closed",
+    source: defaultSource,
+    whatsappUrl: "",
+  });
+
+  const openIntentModal = useCallback(
+    (source: number, whatsappUrl: string) => {
+      if (ctaMode === "direct") {
+        window.open(whatsappUrl, "_blank");
+        return;
+      }
+      if (ctaMode === "lead-only") {
+        setState({ step: "lead-form", source, whatsappUrl });
+        return;
+      }
+      setState({ step: "intent", source, whatsappUrl });
+    },
+    [ctaMode]
+  );
+
+  const goToIntent = useCallback(() => {
+    setState((prev) => ({ ...prev, step: "intent" }));
+  }, []);
+
+  const goToLeadForm = useCallback(() => {
+    setState((prev) => ({ ...prev, step: "lead-form" }));
+  }, []);
+
+  const goToCaregiver = useCallback(() => {
+    setState((prev) => ({ ...prev, step: "caregiver" }));
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setState((prev) => ({ ...prev, step: "closed" }));
+  }, []);
+
+  return (
+    <LeadModalContext.Provider
+      value={{
+        state,
+        ctaMode,
+        defaultSource,
+        openIntentModal,
+        goToIntent,
+        goToLeadForm,
+        goToCaregiver,
+        closeModal,
+      }}
+    >
+      {children}
+    </LeadModalContext.Provider>
+  );
+};
+
+export const useLeadModal = () => {
+  const ctx = useContext(LeadModalContext);
+  if (!ctx) throw new Error("useLeadModal must be used within LeadModalProvider");
+  return ctx;
+};

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,6 +1,9 @@
 import { getEnv } from "./utils";
 
-const whatsappNumber = getEnv("ACUIDAR_WHATSAPP_NUMBER") || "5511958189900";
+export const whatsappNumber = getEnv("ACUIDAR_WHATSAPP_NUMBER") || "5511958189900";
+
+export const buildWhatsAppUrl = (message: string) =>
+  `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`;
 
 export const whatsAppDefaultLink =
   `https://wa.me/${whatsappNumber}?text=Olá,%20gostaria%20de%20mais%20informações%20sobre%20os%20serviços%20da%20Acuidar.`;
@@ -10,3 +13,13 @@ export const whatsAppAlternativeLink =
 
 export const workWithUsLink =
   getEnv("ACUIDAR_WORK_WITH_US_URL") || "https://whatsapp.com/channel/0029VbBeBr6Jf05Uk1rwlP3k";
+
+export const placeId = "ChIJd_dFVTBZzpQRotBOQd5zbro";
+
+export const FormSources = {
+  TESTES: 0,
+  REDE_DE_PESQUISA: 1,
+  P_MAX: 2,
+};
+
+export type CtaMode = "direct" | "lead-only" | "full";

--- a/src/sections/map/map.module.css
+++ b/src/sections/map/map.module.css
@@ -17,6 +17,18 @@
   margin-bottom: 1.5rem;
 }
 
+.map_link {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: #063e24;
+  text-decoration: none;
+  margin-bottom: -0.5rem;
+}
+
+.map_link:hover {
+  text-decoration: underline;
+}
+
 .map {
   width: 100%;
   height: 100%;

--- a/src/sections/map/map.tsx
+++ b/src/sections/map/map.tsx
@@ -1,6 +1,7 @@
 import { GoogleMapsEmbed } from "@next/third-parties/google";
 import styles from "./map.module.css";
 import { getEnv } from "@/modules/utils";
+import { placeId } from "@/modules/constants";
 
 const MapSection = () => (
   <section className={styles.section}>
@@ -11,6 +12,14 @@ const MapSection = () => (
         <span> no conforto do seu lar.</span>
       </span>
     </h2>
+    <a
+      href="https://www.google.com/maps/place/?q=place_id:ChIJd_dFVTBZzpQRotBOQd5zbro"
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.map_link}
+    >
+      Acuidar SP Jardins - Cuidadores de Idosos em São Paulo
+    </a>
     <div className={styles.map}>
       <GoogleMapsEmbed
         apiKey={getEnv("GOOGLE_MAPS_API_KEY")}
@@ -20,9 +29,9 @@ const MapSection = () => (
         language="pt-BR"
         loading="eager"
         mode="place"
+        id={placeId}
         allowfullscreen={false}
-        maptype=""
-        q="Av. Engenheiro Luís Carlos Berrini, 1681 - Cidade Monções, São Paulo - SP, 04571-011"
+        q="Acuidar SP Jardins - Cuidadores de Idosos em São Paulo"
       />
     </div>
   </section>

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,0 +1,7 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export const createClient = () =>
+  createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+  );

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,0 +1,7 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+
+export const createServiceRoleClient = () =>
+  createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.5"
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/5c098e0d7b58c9bc769f276cca1766994c2c9c70c92d091a61bba8b3e9be53c011e0a79a8457fc2fb2f3d91697a26eb52e0a4962ef936dc963b45f58613c212f
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "@floating-ui/react-dom@npm:2.1.8"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.6"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10c0/26260ca4bb23b57c73b824062505abf977a008ce6e0463bdacca74f7e49853c4cd1d2bbf1a77c6caa17fa37dfffda2c6c4cd07a8737ebd7474aaff7818401d75
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:^0.27.15":
+  version: 0.27.19
+  resolution: "@floating-ui/react@npm:0.27.19"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10c0/2a2cdfd3e67e0606833b63f922ad2a9037974f22b944e1cb8c0991b4c40450f8413d69745c0bbf4646e5ba283747f60d2fdc9a8d289b68b24448e59d81a3a96d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: 10c0/f4bcea1559bdbb721ecc8e8ead423ac58d6a5b6e70b602cf0810ba6ad4ed1c77211b207faa88b278a9042f0c743133de08a203ed6741c1b6443423332884d5b3
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -411,6 +463,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@supabase/auth-js@npm:2.105.3":
+  version: 2.105.3
+  resolution: "@supabase/auth-js@npm:2.105.3"
+  dependencies:
+    tslib: "npm:2.8.1"
+  checksum: 10c0/1bbdca31db09f3ae8210d89e25c8b33dac4eebb6a97074e773627a92e9d52a550157c2b3ac3044a1706cd16cc9fd94e58c5c9085e743063ba52536d30b69e17b
+  languageName: node
+  linkType: hard
+
+"@supabase/functions-js@npm:2.105.3":
+  version: 2.105.3
+  resolution: "@supabase/functions-js@npm:2.105.3"
+  dependencies:
+    tslib: "npm:2.8.1"
+  checksum: 10c0/7bc8e09f0cfe33272cd3dc4946afc96d8bfde341f4857ad6f50c3fe68f24f6cb9c3ca99d67bd9811bfedf848d02b7e4a5eaa83a1485e42afe68d185e849270f8
+  languageName: node
+  linkType: hard
+
+"@supabase/phoenix@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@supabase/phoenix@npm:0.4.1"
+  checksum: 10c0/6ab26be2470a2ddb1d61ff5925b90deb2aef8eba7a7664afbee33b192b62d133c95a4e251fbc4c8cf5e23f2918eb20f3f8aa08e99b73535ca04370d084658079
+  languageName: node
+  linkType: hard
+
+"@supabase/postgrest-js@npm:2.105.3":
+  version: 2.105.3
+  resolution: "@supabase/postgrest-js@npm:2.105.3"
+  dependencies:
+    tslib: "npm:2.8.1"
+  checksum: 10c0/d8e284a8ff7924447a43f1ebeb9086b0de9d73862cfa68b2edac45b37108eb99378837cbefb063a1ebd1c0715f2d8049fef157f71ae82944840ebf40712a36ff
+  languageName: node
+  linkType: hard
+
+"@supabase/realtime-js@npm:2.105.3":
+  version: 2.105.3
+  resolution: "@supabase/realtime-js@npm:2.105.3"
+  dependencies:
+    "@supabase/phoenix": "npm:^0.4.1"
+    "@types/ws": "npm:^8.18.1"
+    tslib: "npm:2.8.1"
+    ws: "npm:^8.18.2"
+  checksum: 10c0/726835f05014390a0705fcfb80e7d0c6b1401178a2e8b88e486df51fa81faf1fb82788b79fb757d1f979556bf37154bebd747c217f7e91316f0eec6091bec36e
+  languageName: node
+  linkType: hard
+
+"@supabase/ssr@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "@supabase/ssr@npm:0.10.2"
+  dependencies:
+    cookie: "npm:^1.0.2"
+  peerDependencies:
+    "@supabase/supabase-js": ^2.102.1
+  checksum: 10c0/6d182f622465ff456082728a2affde063b084240d1fbc3207686dddbe96f15cddf1de99f8771deff311f090458b5807acd34735ea952c80718447a7c286cf396
+  languageName: node
+  linkType: hard
+
+"@supabase/storage-js@npm:2.105.3":
+  version: 2.105.3
+  resolution: "@supabase/storage-js@npm:2.105.3"
+  dependencies:
+    iceberg-js: "npm:^0.8.1"
+    tslib: "npm:2.8.1"
+  checksum: 10c0/6d538c6342b50645fa7d3d1d94e88a501c29b4cb97b3ec83a048d72885506e12c8f5caae1cf2d0f65de78a341a7cc4155d51a009e72f119bac72c0b31ed701d0
+  languageName: node
+  linkType: hard
+
+"@supabase/supabase-js@npm:^2.105.3":
+  version: 2.105.3
+  resolution: "@supabase/supabase-js@npm:2.105.3"
+  dependencies:
+    "@supabase/auth-js": "npm:2.105.3"
+    "@supabase/functions-js": "npm:2.105.3"
+    "@supabase/postgrest-js": "npm:2.105.3"
+    "@supabase/realtime-js": "npm:2.105.3"
+    "@supabase/storage-js": "npm:2.105.3"
+  checksum: 10c0/975847e2e59a288acdf43157ec46284a3536d0f8662fc7a393e2720dc0c14e6ff54ea03af358673913bceca9db4163290f4881db92a1a86b90403382443ebf61
+  languageName: node
+  linkType: hard
+
 "@swc/counter@npm:^0.1.3":
   version: 0.1.3
   resolution: "@swc/counter@npm:0.1.3"
@@ -435,6 +567,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:*":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
+  dependencies:
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:20":
   version: 20.14.9
   resolution: "@types/node@npm:20.14.9"
@@ -448,6 +589,15 @@ __metadata:
   version: 15.7.12
   resolution: "@types/prop-types@npm:15.7.12"
   checksum: 10c0/1babcc7db6a1177779f8fde0ccc78d64d459906e6ef69a4ed4dd6339c920c2e05b074ee5a92120fe4e9d9f1a01c952f843ebd550bee2332fc2ef81d1706878f8
+  languageName: node
+  linkType: hard
+
+"@types/react-datepicker@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@types/react-datepicker@npm:7.0.0"
+  dependencies:
+    react-datepicker: "npm:*"
+  checksum: 10c0/8b9efb8841ed9bfb06e3157a2a4c5ed18fd7d6175cf760fb4fece99c0a53a55a5f27ea6484b62f548f2543cae349456c0f912d36243fe34251a25043ba4a1296
   languageName: node
   linkType: hard
 
@@ -467,6 +617,15 @@ __metadata:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/fe455f805c5da13b89964c3d68060cebd43e73ec15001a68b34634604a78140e6fc202f3f61679b9d809dde6d7a7c2cb3ed51e0fd1462557911db09879b55114
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -861,6 +1020,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
@@ -901,6 +1067,13 @@ __metadata:
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
   languageName: node
   linkType: hard
 
@@ -959,6 +1132,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-data-view: "npm:^1.0.1"
   checksum: 10c0/21b0d2e53fd6e20cc4257c873bf6d36d77bd6185624b84076c0a1ddaa757b49aaf076254006341d35568e89f52eecd1ccb1a502cfb620f2beca04f48a6a62a8f
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -1817,6 +1997,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iceberg-js@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "iceberg-js@npm:0.8.1"
+  checksum: 10c0/e504da64cc26e8ad7c5344353a7203c671a740c14eb6086f20505f5e9739cab774493e616032530c962df97f2a855115cc2e89a47dd81581df5917b21a69ec48
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0":
   version: 5.3.1
   resolution: "ignore@npm:5.3.1"
@@ -2281,14 +2468,19 @@ __metadata:
   resolution: "market-campaign@workspace:."
   dependencies:
     "@next/third-parties": "npm:14.2.4"
+    "@supabase/ssr": "npm:^0.10.2"
+    "@supabase/supabase-js": "npm:^2.105.3"
     "@types/node": "npm:20"
     "@types/react": "npm:18"
+    "@types/react-datepicker": "npm:^7.0.0"
     "@types/react-dom": "npm:18"
     eslint: "npm:8"
     eslint-config-next: "npm:14.2.4"
     next: "npm:14.2.4"
     react: "npm:18"
+    react-datepicker: "npm:^9.1.0"
     react-dom: "npm:18"
+    react-hook-form: "npm:^7.75.0"
     react-icons: "npm:5.2.1"
     sharp: "npm:0.33.4"
     swiper: "npm:11.1.4"
@@ -2690,6 +2882,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-datepicker@npm:*, react-datepicker@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "react-datepicker@npm:9.1.0"
+  dependencies:
+    "@floating-ui/react": "npm:^0.27.15"
+    clsx: "npm:^2.1.1"
+    date-fns: "npm:^4.1.0"
+  peerDependencies:
+    date-fns-tz: ^3.0.0
+    react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+  peerDependenciesMeta:
+    date-fns-tz:
+      optional: true
+  checksum: 10c0/43b58b08f9e4f289a31f2a2dbd0e246e396ad44ebfea4ed8d1393de2a6bded2dad9c2002cfcf70dfbe51aabf5f886b12b1aae8463c5bc35d67b1b22733a8a0f9
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:18":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
@@ -2699,6 +2909,15 @@ __metadata:
   peerDependencies:
     react: ^18.3.1
   checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
+  languageName: node
+  linkType: hard
+
+"react-hook-form@npm:^7.75.0":
+  version: 7.75.0
+  resolution: "react-hook-form@npm:7.75.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 10c0/4c264ffde2fae6d5f3158a97784d5bb44e7cbffea3204af364244fcd6921b763f4e66fd8e34423fb416baa8bee2cfa4777556a7245f66de24a28be28b6af172e
   languageName: node
   linkType: hard
 
@@ -3211,6 +3430,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tabbable@npm:^6.0.0":
+  version: 6.4.0
+  resolution: "tabbable@npm:6.4.0"
+  checksum: 10c0/d931427f4a96b801fd8801ba296a702119e06f70ad262fed8abc5271225c9f1ca51b89fdec4fb2f22e1d35acb3d2881db0a17cedc758272e9ecb540d00299d76
+  languageName: node
+  linkType: hard
+
 "tapable@npm:^2.2.0":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
@@ -3259,6 +3485,13 @@ __metadata:
     minimist: "npm:^1.2.6"
     strip-bom: "npm:^3.0.0"
   checksum: 10c0/5b4f301a2b7a3766a986baf8fc0e177eb80bdba6e396792ff92dc23b5bca8bb279fc96517dcaaef63a3b49bebc6c4c833653ec58155780bc906bdbcf7dda0ef5
+  languageName: node
+  linkType: hard
+
+"tslib@npm:2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -3376,6 +3609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -3487,6 +3727,21 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.2":
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Resumo

Implementação completa do sistema de captura de leads e página de análise para a landing page da Acuidar Jardins.

### Lead Capture Modal
- Formulário com validação (Nome, Telefone, E-mail, Bairro, Necessidade)
- Input de telefone com formatação automática `(XX) XXXXX-XXXX` e restrição a apenas números
- Integração com Supabase para persistência dos leads
- Redirecionamento para WhatsApp após envio com mensagem dinâmica por rota

### Intent Routing Modal
- Modal de intenção ("Busco um cuidado" vs "Sou cuidador(a)")
- Fluxo de cuidador redireciona para canal de recrutamento
- Fluxo de cliente abre o formulário de captura

### Rotas com Fluxos Diferenciados
- `/` (root): CTAs redirecionam direto para WhatsApp, sem modais (source: TESTES)
- `/empresa-de-cuidadores`: Apenas formulário simplificado (Nome + Telefone), sem modal de intenção (source: REDE_DE_PESQUISA)
- `/cuidadores`: Fluxo completo com ambos os modais (source: P_MAX)

### Página de Análise de Leads (`/leads/analysis`)
- Autenticação por senha com persistência em localStorage
- Tabela com busca por nome, filtros (data, bairro, source) e paginação (50/página)
- Telefones formatados e clicáveis (link WhatsApp)
- Badges coloridos por source
- Funcionalidade de deletar leads
- Layout responsivo: tabela em desktop/tablet, cards empilhados em mobile
- Custom date-picker (react-datepicker) e custom select components
- Arquitetura modular: tipos compartilhados, source config centralizado, utils extraídos, custom hook para state management

### Infraestrutura
- Supabase client (publishable key) e server (service role key)
- API route `/api/leads` com autenticação para GET e DELETE
- Context provider (`LeadModalProvider`) com step-based state machine
- CSS Modules para todo o styling

## Test plan
- [ ] Verificar que `/` redireciona direto para WhatsApp ao clicar nos CTAs
- [ ] Verificar que `/empresa-de-cuidadores` abre apenas o formulário simplificado
- [ ] Verificar que `/cuidadores` abre o modal de intenção seguido do formulário completo
- [ ] Verificar formatação automática do telefone no formulário
- [ ] Verificar que leads são salvos no Supabase com source correto
- [ ] Verificar que `/leads/analysis` exige senha e mostra a tabela
- [ ] Verificar responsividade da página de leads em mobile (cards) e tablet (tabela compacta)
- [ ] Verificar que `yarn build` compila sem erros


Made with [Cursor](https://cursor.com)