### PR TITLE
refactor: replace getEnv utility with direct process.env access for environment variables

### DIFF
--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleClient } from "@/utils/supabase/server";
-import { getEnv } from "@/modules/utils";
 
 const PAGE_SIZE = 50;
 
 export async function GET(request: NextRequest) {
   const password = request.headers.get("x-admin-password");
 
-  if (!password || password !== getEnv("ADMIN_PASSWORD")) {
+  if (!password || password !== process.env.ADMIN_PASSWORD) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -62,7 +61,7 @@ export async function GET(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const password = request.headers.get("x-admin-password");
 
-  if (!password || password !== getEnv("ADMIN_PASSWORD")) {
+  if (!password || password !== process.env.ADMIN_PASSWORD) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/app/cuidadores-de-idosos/page.tsx
+++ b/src/app/cuidadores-de-idosos/page.tsx
@@ -10,22 +10,19 @@ import {
 import { BodyWrapper } from "@/components";
 
 import styles from "./page.module.css";
-import { getEnv } from "@/modules/utils";
 
 const Home = () => (
   <>
     <Script
       async
-      src={`https://www.googletagmanager.com/gtag/js?id=${getEnv(
-        "ACUIDAR_GTAG_ID"
-      )}`}
+      src={`https://www.googletagmanager.com/gtag/js?id=${process.env.ACUIDAR_GTAG_ID || ""}`}
     ></Script>
     <Script id="gtag-init">
       {`
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', '${getEnv("ACUIDAR_GTAG_ID")}');
+        gtag('config', '${process.env.ACUIDAR_GTAG_ID || ""}');
       `}
     </Script>
     <Script id="gtag-conversion">
@@ -37,9 +34,7 @@ const Home = () => (
             }
           };
           gtag('event', 'conversion', {
-              'send_to': '${getEnv("ACUIDAR_GTAG_ID")}/${getEnv(
-        "ACUIDAR_GTAG_METRIC"
-      )}',
+              'send_to': '${process.env.ACUIDAR_GTAG_ID || ""}/${process.env.ACUIDAR_GTAG_METRIC || ""}';
               'event_callback': callback
           });
           return false;

--- a/src/app/cuidadores/page.tsx
+++ b/src/app/cuidadores/page.tsx
@@ -12,11 +12,10 @@ import { BodyWrapper } from "@/components";
 import { FormSources } from "@/modules/constants";
 
 import styles from "./page.module.css";
-import { getEnv } from "@/modules/utils";
 
 const Cuidadores = () => (
   <>
-    <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
+    <GoogleTagManager gtmId={process.env.ACUIDAR_DEFAULT_GTM || ""} />
     <BodyWrapper ctaMode="full" defaultSource={FormSources.P_MAX}>
       <main className={styles.main}>
         <BannerSection maxHeight="640px" />

--- a/src/app/empresa-de-cuidadores/page.tsx
+++ b/src/app/empresa-de-cuidadores/page.tsx
@@ -12,11 +12,10 @@ import { BodyWrapper } from "@/components";
 import { FormSources } from "@/modules/constants";
 
 import styles from "./page.module.css";
-import { getEnv } from "@/modules/utils";
 
 const EmpresaDeCuidadores = () => (
   <>
-    <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
+    <GoogleTagManager gtmId={process.env.ACUIDAR_DEFAULT_GTM || ""} />
     <BodyWrapper ctaMode="lead-only" defaultSource={FormSources.REDE_DE_PESQUISA}>
       <main className={styles.main}>
         <BannerSection maxHeight="640px" />

--- a/src/app/hot-site/page.tsx
+++ b/src/app/hot-site/page.tsx
@@ -1,13 +1,12 @@
 import { GoogleTagManager } from "@next/third-parties/google";
 
 import styles from "./page.module.css";
-import { getEnv } from "@/modules/utils";
 import { BannerSection } from "@/sections";
 import { Button, BodyWrapper } from "@/components";
 
 const Home = () => (
   <>
-    <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
+    <GoogleTagManager gtmId={process.env.ACUIDAR_DEFAULT_GTM || ""} />
     <BodyWrapper>
       <main className={styles.main}>
         <BannerSection />

--- a/src/app/landing-page/page.tsx
+++ b/src/app/landing-page/page.tsx
@@ -11,11 +11,10 @@ import {
 import { BodyWrapper } from "@/components";
 
 import styles from "./page.module.css";
-import { getEnv } from "@/modules/utils";
 
 const Home = () => (
   <>
-    <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
+    <GoogleTagManager gtmId={process.env.ACUIDAR_DEFAULT_GTM || ""} />
     <BodyWrapper>
       <main className={styles.main}>
         <BannerSection maxHeight="640px" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,11 +11,10 @@ import {
 import { BodyWrapper } from "@/components";
 
 import styles from "./page.module.css";
-import { getEnv } from "@/modules/utils";
 
 const Home = () => (
   <>
-    <GoogleTagManager gtmId={getEnv("ACUIDAR_DEFAULT_GTM")} />
+    <GoogleTagManager gtmId={process.env.ACUIDAR_DEFAULT_GTM || ""} />
     <BodyWrapper ctaMode="direct">
       <main className={styles.main}>
         <BannerSection maxHeight="640px" />

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -1,6 +1,5 @@
-import { getEnv } from "./utils";
 
-export const whatsappNumber = getEnv("ACUIDAR_WHATSAPP_NUMBER") || "5511958189900";
+export const whatsappNumber = process.env.ACUIDAR_WHATSAPP_NUMBER || "5511958189900";
 
 export const buildWhatsAppUrl = (message: string) =>
   `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(message)}`;
@@ -12,7 +11,7 @@ export const whatsAppAlternativeLink =
   `https://wa.me/${whatsappNumber}?text=Olá!%20Gostaria%20de%20mais%20informações%20sobre%20os%20serviços%20da%20Acuidar.`;
 
 export const workWithUsLink =
-  getEnv("ACUIDAR_WORK_WITH_US_URL") || "https://whatsapp.com/channel/0029VbBeBr6Jf05Uk1rwlP3k";
+  process.env.ACUIDAR_WORK_WITH_US_URL || "https://whatsapp.com/channel/0029VbBeBr6Jf05Uk1rwlP3k";
 
 export const placeId = "ChIJd_dFVTBZzpQRotBOQd5zbro";
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,1 +1,0 @@
-export const getEnv = (key: string): string => process.env[key] || "";

--- a/src/sections/map/map.tsx
+++ b/src/sections/map/map.tsx
@@ -1,6 +1,5 @@
 import { GoogleMapsEmbed } from "@next/third-parties/google";
 import styles from "./map.module.css";
-import { getEnv } from "@/modules/utils";
 import { placeId } from "@/modules/constants";
 
 const MapSection = () => (
@@ -22,7 +21,7 @@ const MapSection = () => (
     </a>
     <div className={styles.map}>
       <GoogleMapsEmbed
-        apiKey={getEnv("GOOGLE_MAPS_API_KEY")}
+        apiKey={process.env.GOOGLE_MAPS_API_KEY || ""}
         zoom="16"
         style="width: 100%; height: 100%;"
         height={350}

--- a/src/utils/mail.ts
+++ b/src/utils/mail.ts
@@ -1,16 +1,15 @@
 import nodemailer from "nodemailer";
-import { getEnv } from "@/modules/utils";
 import { sourceLabels } from "@/app/leads/analysis/source-config";
 
 const LOGO_URL = "https://www.acuidarjardins.com.br/acuidar.jpg";
 
 const transporter = nodemailer.createTransport({
-  host: getEnv("SMTP_HOST"),
-  port: Number(getEnv("SMTP_PORT")) || 587,
-  secure: Number(getEnv("SMTP_PORT")) === 465,
+  host: process.env.SMTP_HOST || "",
+  port: Number(process.env.SMTP_PORT) || 587,
+  secure: Number(process.env.SMTP_PORT) === 465,
   auth: {
-    user: getEnv("SMTP_USER"),
-    pass: getEnv("SMTP_PASS"),
+    user: process.env.SMTP_USER || "",
+    pass: process.env.SMTP_PASS || "",
   },
 });
 
@@ -116,11 +115,11 @@ function buildEmailHtml(lead: LeadEmailData): string {
 }
 
 export async function sendLeadNotification(lead: LeadEmailData) {
-  const recipients = getEnv("NOTIFY_RECIPIENTS");
+  const recipients = process.env.NOTIFY_RECIPIENTS || "";
   if (!recipients) return;
 
   await transporter.sendMail({
-    from: `"Acuidar Jardins" <${getEnv("SMTP_USER")}>`,
+    from: `"Acuidar Jardins" <${process.env.SMTP_USER || ""}>`,
     to: recipients,
     subject: `Novo Lead: ${lead.fullName}`,
     html: buildEmailHtml(lead),


### PR DESCRIPTION


Updated multiple components and modules to directly use process.env for accessing environment variables, removing the dependency on the getEnv utility function. This change enhances clarity and simplifies the codebase.